### PR TITLE
fixbug - fix by adding "descriptorRef" under descriptorRefs

### DIFF
--- a/plugins/generalPacket/pom.xml
+++ b/plugins/generalPacket/pom.xml
@@ -53,7 +53,11 @@
                 <configuration>
                     <outputDirectory>../../eat/extraLibrary/</outputDirectory>
                     <appendAssemblyId>false</appendAssemblyId>
-                    <descriptorRefs>jar-with-dependencies</descriptorRefs>
+                    <descriptorRefs>
+                        <descriptorRef>
+                            jar-with-dependencies
+                        </descriptorRef>
+                    </descriptorRefs>
                 </configuration>
                 <executions>
                     <execution>

--- a/plugins/protobuf/pom.xml
+++ b/plugins/protobuf/pom.xml
@@ -46,7 +46,11 @@
                 <configuration>
                     <outputDirectory>../../eat/extraLibrary/</outputDirectory>
                     <appendAssemblyId>false</appendAssemblyId>
-                    <descriptorRefs>jar-with-dependencies</descriptorRefs>
+                    <descriptorRefs>
+                        <descriptorRef>
+                            jar-with-dependencies
+                        </descriptorRef>
+                    </descriptorRefs>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
There is an error while I am installing the projects - "generalPacket" and "protobuf". The error was as following.

```
Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.0.0:single (make-assembly) on project generalPacket_plugin: Unable to parse configuration of mojo org.apache.maven.plugins:maven-assembly-plugin:3.0.0:single for parameter descriptorRefs: Cannot assign configuration entry 'descriptorRefs' with value 'jar-with-dependencies' of type java.lang.String to property of type java.lang.String[] -> [Help 1]
```

So I fixed `pom.xml` as below for the two projects.

```
<descriptorRefs>
  <descriptorRef>
    jar-with-dependencies
  </descriptorRef>
</descriptorRefs>
```